### PR TITLE
Adding public.banano.live (Public Banano Nodes) site

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Please read the [Contributing guide](./Contributing.md).
   - [Account Generator](https://nanoo.tools/quick-banano-account) - Generate a BANANO account from seed
   - [Public RPI API](https://nanoo.tools/bananode-api) - free bananode as-a-service for easy access to the BANANO network
   - [Unit Converter](https://nanoo.tools/banano-units) - RAW to Banano and Banano to RAW conversions
+- [Public Banano Nodes](https://public.banano.live)
 
 ## Client Libraries
 


### PR DESCRIPTION
Hello, I just launched a fork of SomeNano's public Nano node site, but for Banano!

![image](https://user-images.githubusercontent.com/3312219/116114346-20182a00-a66e-11eb-8127-4a1b661a8823.png)

I've included a link to the site under the "Ecosystem" section, as that's probably where it makes the most sense. My contact information is on the site itself and I can also be reached here for maintenance.